### PR TITLE
Fix/loginredirect/add missing favorite api

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "prettier"],
   "extends": [
     "next/core-web-vitals",
     "airbnb-base",
@@ -8,6 +8,7 @@
     "prettier"
   ],
   "rules": {
+    "prettier/prettier": "error",
     "import/extensions": "off",
     "import/prefer-default-export": "off",
     "no-unsafe-optional-chaining": "off",

--- a/package.json
+++ b/package.json
@@ -47,10 +47,11 @@
     "eslint-config-next": "12.0.4",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.3",
+    "eslint-plugin-prettier": "^4.0.0",
     "husky": ">=6",
     "kakao.maps.d.ts": "^0.1.24",
     "lint-staged": ">=10",
-    "prettier": "^2.5.0",
+    "prettier": "^2.5.1",
     "typescript": "4.5.2"
   },
   "lint-staged": {

--- a/src/contexts/AuthProvider/context.ts
+++ b/src/contexts/AuthProvider/context.ts
@@ -16,6 +16,7 @@ export interface ContextProps {
   getMyReservations: () => void;
   readAllNotifications: () => void;
   getMoreNotifications: () => void;
+  authProviderInit: () => void;
 }
 
 const Context = createContext<ContextProps>({} as ContextProps);

--- a/src/contexts/AuthProvider/index.tsx
+++ b/src/contexts/AuthProvider/index.tsx
@@ -210,6 +210,7 @@ const AuthProvider = ({ children }: Props) => {
         readAllNotifications,
         getMoreNotifications,
         unshiftNotification,
+        authProviderInit,
       }}
     >
       <AuthLoading />

--- a/src/pages/login/redirect/index.tsx
+++ b/src/pages/login/redirect/index.tsx
@@ -9,20 +9,20 @@ import { useAuthContext } from "@contexts/hooks";
 const RedirectPage = () => {
   const [isNeedReLogin, setIsNeedReLogin] = useState(false);
   const [_, setToken] = useLocalToken();
-  const { getCurrentUser } = useAuthContext();
+  const { authProviderInit } = useAuthContext();
   const router = useRouter();
   const { token } = router.query;
 
   const getCurrentUserData = useCallback(async () => {
     setToken(token);
     try {
-      await getCurrentUser();
+      await authProviderInit();
       router.replace("/");
     } catch (error) {
       console.error(error);
       setIsNeedReLogin(true);
     }
-  }, [token, getCurrentUser, setToken]);
+  }, [token, authProviderInit, setToken]);
 
   useEffect(() => {
     if (token) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2990,6 +2990,13 @@ eslint-plugin-jsx-a11y@^6.4.1:
     language-tags "^1.0.5"
     minimatch "^3.0.4"
 
+eslint-plugin-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
+  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-plugin-react-hooks@^4.2.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz"
@@ -3218,6 +3225,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-equals@^2.0.1:
   version "2.0.3"
@@ -5715,10 +5727,17 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.0.tgz#a6370e2d4594e093270419d9cc47f7670488f893"
-  integrity sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 pretty-bytes@^5.6.0:
   version "5.6.0"


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
즐겨찾기 별표시 누락 문제 해결입니다

AuthProvider에서 뿌려주는 authProviderInit는 아래 3함수를 순차적으로 호출하는 wrapping 함수입니다.
- getCurrentUser (me)
- getFavorites (favorites)
- getReservations (reservations)

백엔드 측에서 getCurrentUser에서 한번에 favorites와 reservations를 뿌려주지 못하기 때문에 따로 여러번 호출합니다.

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->
closes #1 

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->
- eslint prettier 세팅 추가
- 즐겨찾기 표시 문제 해결