### PR TITLE
유저페이지 타이틀이 undefined로 표시되는 문제 해결

### DIFF
--- a/src/pages/user/[userId]/index.tsx
+++ b/src/pages/user/[userId]/index.tsx
@@ -23,6 +23,7 @@ import {
   getTranslatedProficiency,
 } from "@utils/userInfo";
 import Custom404 from "@pages/404";
+import useIsomorphicLayoutEffect from "@hooks/useIsomorphicLayoutEffect";
 
 type ResponseUserProfile = {
   createdAt: string;
@@ -116,7 +117,7 @@ const User: NextPage = UtilRoute("private", () => {
     }
   };
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     setNavigationTitle(`${pageUserInfo?.nickname}`);
   }, [pageUserInfo?.nickname, setNavigationTitle]);
 


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
유저페이지에 title이 undefined로 뜨던 문제해결했습니다

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->

closes #8 

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->
useIsomorphicLayout으로 해결했습니다.

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![chrome-capture (13)](https://user-images.githubusercontent.com/61593290/151501651-7d634234-b26b-436c-b3a7-81ac5995986d.gif)

