### PR TITLE
(긴급🚨 ) 변경된 API에 맞게 유저 관련 타이핑, 수정 / API request 최적화

### DIFF
--- a/src/contexts/AuthProvider/index.tsx
+++ b/src/contexts/AuthProvider/index.tsx
@@ -9,6 +9,8 @@ import {
   notificationApi,
 } from "@service/.";
 import { Notification, EditableUserProfile } from "@domainTypes/.";
+import { APIUser } from "@domainTypes/tobe/user";
+import { APINotification } from "@domainTypes/tobe/notification";
 import Context from "./context";
 import { initialData, reducer } from "./reducer";
 import { authTypes } from "./actionTypes";
@@ -35,9 +37,12 @@ const AuthProvider = ({ children }: Props) => {
     }, LOG_OUT_LOGO_ANIMATION_DELAY_TIME_MS);
   }, [router]);
 
-  const setCurrentUser = useCallback((data) => {
-    dispatch({ type: authTypes.SET_CURRENT_USER, payload: data });
-  }, []);
+  const setCurrentUser = useCallback(
+    (data: { user: APIUser; notifications: APINotification[] }) => {
+      dispatch({ type: authTypes.SET_CURRENT_USER, payload: data });
+    },
+    []
+  );
 
   const getCurrentUser = useCallback(async () => {
     dispatch({ type: authTypes.LOADING_ON });

--- a/src/contexts/AuthProvider/reducer.ts
+++ b/src/contexts/AuthProvider/reducer.ts
@@ -55,21 +55,23 @@ export const reducer: Reducer<DataProps, ReducerAction> = (
 ) => {
   switch (type) {
     case authTypes.SET_CURRENT_USER: {
+      const { user, notifications } = payload;
+
       return {
         ...prevState,
         currentUser: {
           ...prevState.currentUser,
-          userId: payload.userId,
-          nickname: payload.nickname,
-          notifications: [...payload.notifications],
-          email: payload.email,
-          positions: payload.positions,
-          proficiency: payload.proficiency,
-          profileImageUrl: payload.profileImage,
-          role: payload.role,
-          description: payload.description,
+          userId: user.id,
+          nickname: user.nickname,
+          notifications: [...notifications],
+          email: user.email,
+          positions: user.positions,
+          proficiency: user.proficiency,
+          profileImageUrl: user.profileImage,
+          role: user.role,
+          description: user.description,
           notificationLastId:
-            payload.notifications[payload.notifications.length - 1]?.id || null,
+            notifications[notifications.length - 1]?.id || null,
         },
       };
     }

--- a/src/domainTypes/tobe/user.ts
+++ b/src/domainTypes/tobe/user.ts
@@ -8,6 +8,7 @@ export interface APIUser extends APICommon {
   role: Role;
   positions: PositionKey[];
   proficiency: ProficiencyKey;
+  email: string;
 }
 
 export type EditableUserProfile = Pick<

--- a/src/service/userApi/type.ts
+++ b/src/service/userApi/type.ts
@@ -1,8 +1,17 @@
+import { APINotification } from "@domainTypes/tobe/notification";
+import { APIUser } from "@domainTypes/tobe/user";
 import { ApiPromise } from "@service/type";
 
 export interface UserApi {
-  getUserData: () => ApiPromise;
-  getMyProfile: () => ApiPromise;
+  getUserData: () => ApiPromise<{
+    user: APIUser;
+    notifications: APINotification[];
+  }>;
+  getMyProfile: () => ApiPromise<{
+    followerCount: number;
+    followingCount: number;
+    user: APIUser;
+  }>;
   getUserProfile: (...params: any[]) => ApiPromise;
   updateMyProfile: (...params: any[]) => ApiPromise;
   updateMyProfileImage: (...params: any[]) => ApiPromise;


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
- [x] user[userId] 페이지 api 콜 최적화 (3 -> 1번)
- [x] NaN은 userId가 없을 경우에 보낸 콜이기 때문에 if문으로 보내지 않도록 처리했습니다.
- [x] 변경된 response에 맞게 api타이핑 및 관련함수, reducer 변경

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->

closes #54 

## 📌 PR포인트
1. 로컬 서버를 develop에 맞추고 하셔야 합니다
2. 나의 유저페이지와 다른 사람의 페이지를 들어가주세요
3. 프론트와 백 모두 배포하기 전까지 로컬 서버를 켜고 작업해주세요

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
원래 3번의 user/[userId]로 3번의 request 요청하게 되는데
useEffect에서 최적화 처리했기 때문에 아래와 같이 한번만 요청하게 됩니다
![image](https://user-images.githubusercontent.com/61593290/151523406-d7c96d17-322a-4464-9091-39952841f8a5.png)
