### PR TITLE
접근성과 검색엔진최적화를 위한 Avatar와 LinkAvatar에 기본 alt속성 추가

### DIFF
--- a/src/components/base/Avatar/index.tsx
+++ b/src/components/base/Avatar/index.tsx
@@ -26,7 +26,7 @@ const Avatar = ({
   size = 70,
   shape = "round",
   placeholder,
-  alt,
+  alt = "avatar",
   mode = "cover",
   __TYPE = "Avatar",
   isEdit = false,

--- a/src/components/domain/LinkAvatar/index.tsx
+++ b/src/components/domain/LinkAvatar/index.tsx
@@ -21,9 +21,15 @@ interface Props {
   userId?: string | number;
   imageUrl: string;
   size?: Size | number;
+  alt?: string;
 }
 
-const LinkAvatar = ({ userId, imageUrl, size = "middle" }: Props) => {
+const LinkAvatar = ({
+  userId,
+  imageUrl,
+  size = "middle",
+  alt = "link_avatar",
+}: Props) => {
   return (
     <Link href={`/user/${userId}`} passHref>
       <a>
@@ -31,6 +37,7 @@ const LinkAvatar = ({ userId, imageUrl, size = "middle" }: Props) => {
           size={typeof size === "number" ? size : getSize(size)}
           src={imageUrl}
           shape="circle"
+          alt={alt}
         />
       </a>
     </Link>


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
Lighthouse 테스트점수 향상시켰습니다. (즐겨찾기 페이지 기준)
- Accessibility: 74 -> 85점
- SEO: 92 -> 100점

나머지는 차차 채워가서 최고의 성능 최적화를 이뤄봅시다

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->

closes #62 

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->
LinkAvatar와 Avatar에 alt을 기본값으로 주고 있습니다
후에 각 유저의 상황에 따라 alt를 manudeli's avatar등으로 수정하면 더 좋을 거 같습니다.

## 📸 PR 이전
![image](https://user-images.githubusercontent.com/61593290/151641624-14d3892b-8d31-42b7-adc9-f575a7867980.png)
![image](https://user-images.githubusercontent.com/61593290/151641633-973dff16-065c-4410-bc6c-a2d020a0319c.png)

## 📸 PR 이후
![image](https://user-images.githubusercontent.com/61593290/151641736-87109f67-4c2d-4980-98c9-69634c79c646.png)
![image](https://user-images.githubusercontent.com/61593290/151641721-ad4d9493-a056-4af7-ab0f-56e3ab452899.png)
