### PR TITLE
(우선순위🚨) 변경된 API의 객체 id가 number | string일 수 있는 경우 대응

### DIFF
--- a/src/domainTypes/tobe/chatroom.ts
+++ b/src/domainTypes/tobe/chatroom.ts
@@ -4,7 +4,7 @@ import type { APICommon } from "./common";
 import type { APICourt } from "./court";
 import type { APIUser } from "./user";
 
-export interface APIChatroom extends APICommon {
+export interface APIChatroom extends APICommon<string> {
   admins: Admin[];
   type: ChatroomType;
   court?: APICourt;

--- a/src/domainTypes/tobe/common.ts
+++ b/src/domainTypes/tobe/common.ts
@@ -1,11 +1,11 @@
 import type { APIUser } from "./user";
 
-export interface APISend extends APICommon {
+export interface APISend<I = string> extends APICommon<I> {
   sender: APIUser;
 }
 
-export interface APICommon {
-  id: number;
+export interface APICommon<I = number> {
+  id: I;
   createdAt: ISOString;
   updatedAt: ISOString;
 }

--- a/src/domainTypes/tobe/follow.ts
+++ b/src/domainTypes/tobe/follow.ts
@@ -1,6 +1,6 @@
 import type { OmitAt, APISend } from "./common";
 import type { APIUser } from "./user";
 
-export interface APIFollow extends APISend {
+export interface APIFollow extends APISend<string> {
   receiver: OmitAt<APIUser>;
 }

--- a/src/domainTypes/tobe/loudspeaker.ts
+++ b/src/domainTypes/tobe/loudspeaker.ts
@@ -1,7 +1,7 @@
 import type { ISOString, OmitAt, APICommon } from "./common";
 import type { APICourt } from "./court";
 
-export interface APILoudspeaker extends APICommon {
+export interface APILoudspeaker extends APICommon<string> {
   startTime: ISOString;
   court: OmitAt<APICourt>;
 }

--- a/src/domainTypes/tobe/newCourt.ts
+++ b/src/domainTypes/tobe/newCourt.ts
@@ -1,6 +1,7 @@
 import { StatusKey } from "enums/.";
 import { APICourt } from "./court";
 
-export interface APINewCourt extends APICourt {
+export interface APINewCourt extends Omit<APICourt, "id"> {
+  id: string;
   status: StatusKey;
 }

--- a/src/domainTypes/tobe/notification.ts
+++ b/src/domainTypes/tobe/notification.ts
@@ -3,7 +3,7 @@ import type { APICommon, OmitAt } from "./common";
 import type { APIFollow } from "./follow";
 import type { APILoudspeaker } from "./loudspeaker";
 
-export interface APINotification extends APICommon {
+export interface APINotification extends APICommon<string> {
   type: NotificationType;
   follow?: OmitAt<APIFollow>;
   loudspeaker?: OmitAt<APILoudspeaker>;

--- a/src/domainTypes/tobe/reservation.ts
+++ b/src/domainTypes/tobe/reservation.ts
@@ -1,7 +1,7 @@
 import { APICommon, OmitAt } from "./common";
 import { APICourt } from "./court";
 
-export interface APIReservation extends APICommon {
+export interface APIReservation extends APICommon<string> {
   numberOfReservations: number;
   startTime: string;
   endTime: string;

--- a/src/pages/user/edit/index.tsx
+++ b/src/pages/user/edit/index.tsx
@@ -36,7 +36,17 @@ const UserEditPage: NextPage = UtilRoute("private", () => {
   const getMyProfile = useCallback(async () => {
     try {
       const { data } = await userApi.getMyProfile();
-      setPageUserInfo(data);
+
+      const { description, nickname, positions, proficiency, profileImage } =
+        data.user;
+
+      setPageUserInfo({
+        description,
+        nickname,
+        positions,
+        proficiency,
+        profileImage,
+      });
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
JavaScript의 문제인 number타입의 900억개 이상의 수를 표시하지 못하는 문제때문에 id가 number이면 안되는 인터페이스들이 있습니다.
domainType/common의 APICommon이 제네릭으로 id타입을 변경할 수 있게끔 만들어 해결했습니다.

따라서 id가 두타입으로 올 예정인 것으로 백엔드에서 정해졌는데 이에 따른 변화점입니다.
user, court같은 경우에는 id를 number타입으로 남겨두었습니다.
chat, notification, reservation 등 같은 id가 900억개 이상 넘어갈 가능성이 있는 인터페이스의 경우 id를 string타입으로 제네릭으로 받을 수 있도록 변경했습니다.

하지만 Java에서도 id가 900조 이상의 number 타입도 문제가 생깁니다. 또한
개발 생산성을 위해 앞으로 발생할 수 있는 id타입의 문제를 해결하기 위해 id를 uuid로 모두 통일하면 좋겠습니다.
두가지 타입을 받아서 처리할 생각을 하니 어렵네요.. 

마찬가지로 보낼 때에도 두가지 타입의 형태로 보내게 될텐데 차라리 uuid로 통일되는 것이 필요할 것 같습니다.

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->
closes #69 

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![image](https://user-images.githubusercontent.com/61593290/151663881-0242a59b-b81a-429b-870a-48ee5766adec.png)
