### PR TITLE
클라이언트 / 서버의 width값이 다른 에러가 나오는 error가 나오는 문제 해결 및 Paragraph 변수명과 성능최적화

### DIFF
--- a/src/components/base/Skeleton/Paragraph.tsx
+++ b/src/components/base/Skeleton/Paragraph.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import Box from "./Box";
 
 interface Props {
@@ -17,26 +18,31 @@ const Paragraph = ({
   lineBreak = 4,
   ...props
 }: Props) => {
-  // 정갈한 Paragraph 모양을 위한 Step Percentage
-
-  const middleWidthRandomRatio = () => 80 + Math.floor(Math.random() * 20);
-  const lastWidthRandomRatio = () => 20 + Math.floor(Math.random() * 80);
-
   const stepWidth = (ratio: number) =>
     Math.floor(ratio / stepPercentage) * stepPercentage;
+
+  // 정갈한 Paragraph 모양을 위한 Step Percentage
+  const middleLineWidthRandomRatio = useMemo(
+    () => stepWidth(80 + Math.floor(Math.random() * 20)),
+    []
+  );
+  const lastLineWidthRandomRatio = useMemo(
+    () => stepWidth(20 + Math.floor(Math.random() * 80)),
+    []
+  );
 
   return (
     <div {...props} style={{ fontSize, lineHeight }}>
       {Array.from(Array(line), (_, index) =>
         index === line - 1 ? (
           <Box
-            width={`${stepWidth(lastWidthRandomRatio())}%`}
+            width={`${lastLineWidthRandomRatio}%`}
             height={fontSize}
             key={index}
           />
         ) : (index + 1) % lineBreak === 0 ? (
           <Box
-            width={`${stepWidth(middleWidthRandomRatio())}%`}
+            width={`${middleLineWidthRandomRatio}%`}
             height={fontSize}
             key={index}
           />

--- a/src/components/domain/Favorites/index.tsx
+++ b/src/components/domain/Favorites/index.tsx
@@ -5,10 +5,17 @@ import UtilRoute from "UtilRoute";
 import styled from "@emotion/styled";
 import { Button, Spacer } from "@components/base";
 import { useAuthContext, useNavigationContext } from "@contexts/hooks";
-import Paragraph from "@components/base/Skeleton/Paragraph";
 import favoriteAPI from "@service/favoriteApi";
+import dynamic from "next/dynamic";
 import CourtItem from "../CourtItem";
 import NoItemMessage from "../NoItemMessage";
+
+const SkeletonParagraph = dynamic(
+  () => import("../../base/Skeleton/Paragraph"),
+  {
+    ssr: false,
+  }
+);
 
 declare global {
   interface Window {
@@ -53,15 +60,16 @@ const Favorites: NextPage = UtilRoute("private", () => {
   if (isLoading) {
     return (
       <Spacer gap="base" type="vertical">
-        <FavoriteItem>
-          <Paragraph line={4} fontSize={20} lineHeight={2.0} lineBreak={1} />
-        </FavoriteItem>
-        <FavoriteItem>
-          <Paragraph line={4} fontSize={20} lineHeight={2.0} lineBreak={1} />
-        </FavoriteItem>
-        <FavoriteItem>
-          <Paragraph line={4} fontSize={20} lineHeight={2.0} lineBreak={1} />
-        </FavoriteItem>
+        {[0, 1, 2].map((key) => (
+          <FavoriteItem key={key}>
+            <SkeletonParagraph
+              line={4}
+              fontSize={20}
+              lineHeight={2.0}
+              lineBreak={1}
+            />
+          </FavoriteItem>
+        ))}
       </Spacer>
     );
   }


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
클라이언트 / 서버의 width값이 다른 에러가 나오는 error가 나오는 문제를 해결했습니다.
Math.random()으로 생성된 props를 받기 때문인데요

서버와 클라이언트가 다른 속성의 element를 갖는 html을 갖게 되니 error를 뱉어주는 정상적인 에러였습니다.
next의 dynamic import 를 사용해 서버사이드에서 임포트하지 않도록 처리했습니다.

처음에는 디자인시스템에서 건들까 하다가 디자인 시스템에서보다 atom을 사용하는 외부에서 dynamic import를 걸어주는 편이 좀 nextjs프레임워크와의 더 의존성 분리가 명확하다고 생각해서 디자인시스템 외부에서 작업했습니다.

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->

closes #72 

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->
- [x] random 계산 부분 불필요한 연산 최적화
- [x] dynamic import를 통한 에러 해결

## 📸 문제 상황 사진 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![image](https://user-images.githubusercontent.com/61593290/151674679-256553fd-74e5-4096-a804-d7e7520db46d.png)

## 📸 해결된 사진 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![image](https://user-images.githubusercontent.com/61593290/151674654-fed5d2ba-9958-4375-a4fe-95561e4f4ef9.png)

