### PR TITLE
폰트 cors문제와 safari 폰트 및 크로스브라우징 문제 해결

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
-}
+};

--- a/src/components/domain/CourtItem/style.tsx
+++ b/src/components/domain/CourtItem/style.tsx
@@ -16,7 +16,7 @@ const SubHeader = styled(Text)`
 `;
 
 const AddressText = styled(SubHeader)`
-  color: ${({ theme }) => theme.colors.gray500};
+  color: ${({ theme }) => theme.colors.gray700};
 `;
 
 const SUNDAY_INDEX = 0;

--- a/src/components/domain/NoItemMessage/index.tsx
+++ b/src/components/domain/NoItemMessage/index.tsx
@@ -54,7 +54,7 @@ const NoItemMessage = ({
 export default NoItemMessage;
 
 const TextGray = styled(Text)`
-  color: ${({ theme }) => theme.colors.gray500};
+  color: ${({ theme }) => theme.colors.gray700};
 `;
 
 const SearchButton = styled(Button)`

--- a/src/components/domain/NoItemMessage/index.tsx
+++ b/src/components/domain/NoItemMessage/index.tsx
@@ -1,8 +1,9 @@
-import { Button, Icon, Image, Spacer, Text } from "@components/base";
+import type { CSSProperties } from "react";
+import { Button, Icon, Spacer, Text } from "@components/base";
 import styled from "@emotion/styled";
 import Link from "next/link";
-import type { CSSProperties } from "react";
 import React from "react";
+import Image from "next/image";
 
 interface Props {
   title: string;
@@ -26,13 +27,12 @@ const NoItemMessage = ({
         height={170}
         src={
           type === "favorite"
-            ? "assets/basketball/fire_off_favorited.gif"
+            ? "/assets/basketball/fire_off_favorited.gif"
             : type === "reservation"
-            ? "assets/basketball/fire_off_reservated.gif"
-            : "assets/basketball/animation_off_400.png"
+            ? "/assets/basketball/fire_off_reservated.gif"
+            : "/assets/basketball/animation_off_400.png"
         }
         alt="basketball"
-        style={{ marginBottom: -4 }}
       />
       <Spacer gap="xxs" type="vertical" style={{ textAlign: "center" }}>
         <Text size="md" block strong>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -13,7 +13,7 @@ class MyDocument extends Document {
 
   render(): ReactElement {
     return (
-      <Html>
+      <Html lang="ko">
         <Head>
           <script
             async

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -29,6 +29,10 @@ class MyDocument extends Document {
             type="text/css"
             href="https://fonts.googleapis.com/css2?family=Righteous&display=swap"
           />
+          <link
+            href="https://spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css"
+            rel="stylesheet"
+          />
         </Head>
         <body>
           <Main />

--- a/src/pages/courts/[courtId]/[date].tsx
+++ b/src/pages/courts/[courtId]/[date].tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useReducer, useState, Reducer } from "react";
+import { useCallback, useEffect, useState } from "react";
 import dayjs from "dayjs";
 
 import { ModalSheet, Text } from "@components/base";


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
- 폰트로드시 cors문제를 해결해 lighthouse 점수 상승시켰습니다.
- safari의 폰트가 적용되지 않는 문제를 해결했습니다.
- head태그의 속성 lang을 추가해 접근성 점수를 향상 시켰습니다.
- gif처럼 큰 이미지가 나올 때 엑스박스가 나오던 문제를 해결했습니다.


### Lighthouse 점수 100점 🥳
![image](https://user-images.githubusercontent.com/61593290/151677068-13c96724-aeea-41ff-83b6-6ef431de99e5.png)
![image](https://user-images.githubusercontent.com/61593290/151677108-086b5860-e997-4c3c-a7cb-61fb1a7c4012.png)

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->

closes #65 #26 #76 

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->
- [x] 폰트 로딩 css에서 빼기

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
### 사파리 폰트 대응 📸
![image](https://user-images.githubusercontent.com/61593290/151675510-b2939cbe-183a-4d82-ac0a-8b534bc79185.png)

### 변경 전 📸
![image](https://user-images.githubusercontent.com/61593290/151677011-0ed2b1b9-eb18-4526-96a1-a42267127000.png)
### 변경 후 📸
![image](https://user-images.githubusercontent.com/61593290/151676991-4a7cbf8b-35e3-480d-80fe-c27ebe0cda5c.png)



