### PR TITLE
Google Analytics 4 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "next": "^12.0.8",
     "react": "17.0.2",
     "react-dom": "^17.0.2",
+    "react-ga4": "^1.4.1",
     "react-lottie": "^1.2.3",
     "react-modal-sheet": "^1.4.1",
     "sockjs-client": "^1.5.2",

--- a/src/contexts/AnalyticsProvider/context.ts
+++ b/src/contexts/AnalyticsProvider/context.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+export interface ContextProps {
+  sendPageview: (pathname: string) => void;
+}
+
+const Context = createContext<ContextProps>({} as ContextProps);
+
+export default Context;

--- a/src/contexts/AnalyticsProvider/handle.ts
+++ b/src/contexts/AnalyticsProvider/handle.ts
@@ -1,0 +1,8 @@
+import GA from "react-ga4";
+import { ContextProps } from "./context";
+
+export const sendPageview: ContextProps["sendPageview"] = (
+  pathname: string
+) => {
+  GA.send({ hitType: "pageview", page: pathname });
+};

--- a/src/contexts/AnalyticsProvider/hooks.ts
+++ b/src/contexts/AnalyticsProvider/hooks.ts
@@ -1,0 +1,15 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import GA from "react-ga4";
+import { sendPageview } from "./handle";
+
+const trackingId = process.env
+  .NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID as string;
+
+export const useInitialize = () =>
+  useEffect(() => GA.initialize([{ trackingId }]), []);
+
+export const usePageSend = () => {
+  const { pathname } = useRouter();
+  useEffect(() => sendPageview(pathname), [pathname]);
+};

--- a/src/contexts/AnalyticsProvider/index.tsx
+++ b/src/contexts/AnalyticsProvider/index.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from "react";
+import Context from "./context";
+import { useInitialize, usePageSend } from "./hooks";
+import { sendPageview } from "./handle";
+
+interface Props {
+  children: ReactNode;
+}
+
+const AnalyticsProvider = ({ children }: Props) => {
+  useInitialize();
+  usePageSend();
+
+  return (
+    <Context.Provider value={{ sendPageview }}>{children}</Context.Provider>
+  );
+};
+
+export default AnalyticsProvider;

--- a/src/contexts/Providers.tsx
+++ b/src/contexts/Providers.tsx
@@ -6,6 +6,7 @@ import {
   MapProvider,
   ReservationProvider,
 } from ".";
+import AnalyticsProvider from "./AnalyticsProvider";
 
 interface Props {
   children: ReactNode;
@@ -17,7 +18,9 @@ const Providers = ({ children }: Props) => {
       <SocketProvider>
         <NavigationProvider>
           <ReservationProvider>
-            <MapProvider>{children}</MapProvider>
+            <MapProvider>
+              <AnalyticsProvider>{children}</AnalyticsProvider>
+            </MapProvider>
           </ReservationProvider>
         </NavigationProvider>
       </SocketProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5276,6 +5276,11 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-ga4@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-1.4.1.tgz#6ee2a2db115ed235b2f2092bc746b4eeeca9e206"
+  integrity sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w==
+
 react-is@17.0.2, react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
### 구글 애널리틱스 4 추가했습니다

## 기능
- 유저 접속 시간 / 위치를 수집합니다.
- 시간대별 웹사이트 접속 인원을 수집합니다.
- 페이지가 바뀔 때마다 pathname을 수집되게 됩니다.

### 더 필요한 수집 내용이 있다면 점진적으로 추가해봅시다. (아래 제안 내용)
- 예약과정 트래킹
- 팔로우 취소 사유
- 각 버튼 별 사용빈도 측정

개발용 / 프로덕션용 분리를 위해 워크스페이스를 나누어 env.local로 분기해 따로 측정하고 있습니다.
프로덕션용 env에도 프로덕션용 환경변수 추가했습니다 (https://app.netlify.com/sites/slamsapp/settings/deploys#environment)

또한 아래 링크에서 수집 내용을 확인하실 수 있습니다

- 🔗 개발용 구글 애널리틱스 보고서
https://analytics.google.com/analytics/web/?authuser=0#/p301851239/realtime/overview
- 🔗 프로덕션용 구글 애널리틱스 보고서
https://analytics.google.com/analytics/web/?authuser=0#/p301844578/realtime/overview

### 📌 .env.local 업데이트 하셔야 합니다. slack 공지를 참고해주세요

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->

closes #35 

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![image](https://user-images.githubusercontent.com/61593290/151849252-cdb3088d-d239-48d5-a481-2eb62c8362cf.png)

