### PR TITLE
newCourt 타이핑 및 새 농구장 추가 페이지 useForm 로직 수정

### DIFF
--- a/src/components/domain/ProfileForm/index.tsx
+++ b/src/components/domain/ProfileForm/index.tsx
@@ -225,7 +225,9 @@ const ProfileForm = () => {
               {values.nickname.length}/{LENGTH_LIMIT_NICKNAME}
             </LetterCount>
             <div>
-              <ErrorMessage size="sm">{errors.nickname}</ErrorMessage>
+              <ErrorMessage size="sm" block>
+                {errors.nickname}
+              </ErrorMessage>
             </div>
           </div>
           <div>
@@ -248,7 +250,9 @@ const ProfileForm = () => {
               {LENGTH_LIMIT_DESCRIPTION}
             </LetterCount>
             <div>
-              <ErrorMessage size="sm">{errors.description}</ErrorMessage>
+              <ErrorMessage size="sm" block>
+                {errors.description}
+              </ErrorMessage>
             </div>
           </div>
           <div>
@@ -258,7 +262,9 @@ const ProfileForm = () => {
               onChange={handleChangePositions}
             />
             <div>
-              <ErrorMessage size="sm">{errors.positions}</ErrorMessage>
+              <ErrorMessage size="sm" block>
+                {errors.positions}
+              </ErrorMessage>
             </div>
           </div>
           <div>
@@ -268,7 +274,9 @@ const ProfileForm = () => {
               onChange={handleChangeProficiency}
             />
             <div>
-              <ErrorMessage size="sm">{errors.proficiency}</ErrorMessage>
+              <ErrorMessage size="sm" block>
+                {errors.proficiency}
+              </ErrorMessage>
             </div>
           </div>
         </Container>

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -22,6 +22,7 @@ const useForm = <T, H extends HTMLElement = HTMLFormElement>({
     const newError = validate(values);
     setErrors(newError);
   }, [values]);
+
   const handleSubmit = async (e: FormEvent<H>) => {
     setIsLoading(true);
     e.preventDefault();

--- a/src/pages/courts/create.tsx
+++ b/src/pages/courts/create.tsx
@@ -54,7 +54,6 @@ const CreateCourt: NextPage = () => {
   const [level, setLevel] = useState<number>(3);
   const [center, setCenter] = useState<Coord>();
   const [position, setPosition] = useState<Coord>();
-  const [savedPosition, setSavedPosition] = useState<Coord>();
   const [address, setAddress] = useState<string>();
   const [validatedBasketCount, setValidatedBasketCount] = useState(1);
   const [isOpenConfirmModal, setIsOpenConfirmModal] = useState<boolean>(false);
@@ -113,8 +112,11 @@ const CreateCourt: NextPage = () => {
 
   const savedLocation = () => {
     setOpen(false);
-    setSavedPosition(position);
-    setCenter(position);
+    if (position) {
+      const [latitude, longitude] = position;
+      setValues((prev) => ({ ...prev, latitude, longitude }));
+      setCenter(position);
+    }
   };
 
   useEffect(() => {
@@ -124,34 +126,22 @@ const CreateCourt: NextPage = () => {
   const { values, errors, isLoading, setValues, handleSubmit } =
     useForm<Values>({
       initialValues: {
+        longitude: 0,
+        latitude: 0,
         image: null,
         texture: null,
         basketCount: 1,
         name: "",
       },
       onSubmit: async (values) => {
-        if (position) {
-          const [longitude, latitude] = position;
-          const valuesWithPosition = {
-            longitude,
-            latitude,
-            name: values.name,
-            basketCount: values.basketCount,
-            texture: values.texture,
-            image: values.image,
-          };
-
-          setIsOpenConfirmModal(true);
-
-          try {
-            await courtApi.createNewCourt(valuesWithPosition);
-            router.push("/courts");
-          } catch (error) {
-            console.log(error);
-          }
+        try {
+          await courtApi.createNewCourt(values);
+          router.push("/courts");
+        } catch (error) {
+          console.error(error);
         }
       },
-      validate: ({ basketCount, name }) => {
+      validate: ({ basketCount, name, longitude, latitude }) => {
         const errors: Error<Values> = {};
 
         if (!name) {
@@ -160,7 +150,7 @@ const CreateCourt: NextPage = () => {
         if (basketCount < 1) {
           errors.basketCount = "골대 개수를 입력해주세요.";
         }
-        if (!savedPosition) {
+        if (!longitude || !latitude) {
           errors.longitude = "위치를 지정해주세요.";
         }
 
@@ -257,12 +247,14 @@ const CreateCourt: NextPage = () => {
                 isRequired
                 visibleError={!!errors.name}
               />
-              <div>{errors.name}</div>
+              <ErrorMessage size="sm" block>
+                {errors.name}
+              </ErrorMessage>
             </div>
             <div>
               <Label isRequired>위치</Label>
               <PreviewContainer>
-                {savedPosition && !isOpen ? (
+                {values.latitude && values.longitude && !isOpen ? (
                   <div>
                     <AddressGuide>
                       <DecoIcon name="map-pin" color="#FE6D04" size="sm" />
@@ -271,7 +263,7 @@ const CreateCourt: NextPage = () => {
                     <div style={{ position: "relative" }}>
                       <Map.KakaoMap
                         level={level}
-                        center={savedPosition}
+                        center={[values.latitude, values.longitude]}
                         draggable={false}
                         zoomable={false}
                         style={{
@@ -279,7 +271,10 @@ const CreateCourt: NextPage = () => {
                           height: "150px",
                         }}
                       >
-                        <GeneralMarker map={map!} position={savedPosition} />
+                        <GeneralMarker
+                          map={map!}
+                          position={[values.latitude, values.longitude]}
+                        />
                       </Map.KakaoMap>
                       <MoveToMap onClick={() => setOpen(true)} />
                     </div>
@@ -297,7 +292,9 @@ const CreateCourt: NextPage = () => {
                   </PreviewBanner>
                 )}
               </PreviewContainer>
-              <div>{errors.longitude}</div>
+              <ErrorMessage size="sm" block>
+                {errors.longitude}
+              </ErrorMessage>
             </div>
             <div>
               <Input
@@ -314,25 +311,40 @@ const CreateCourt: NextPage = () => {
                 value={validatedBasketCount}
                 visibleError={!!errors.basketCount}
               />
-              <div>{errors.basketCount}</div>
+              <ErrorMessage size="sm" block>
+                {errors.basketCount}
+              </ErrorMessage>
             </div>
           </Spacer>
         </MainContainer>
-        <BottomFixedButton type="submit" onClick={(e) => handleSubmit(e)}>
+        <BottomFixedButton
+          type="submit"
+          onClick={() => setIsOpenConfirmModal(true)}
+          disabled={!!Object.keys(errors).length}
+        >
           {isLoading ? "Loading..." : "새 농구장 추가 제안하기"}
         </BottomFixedButton>
       </form>
 
       <LeadToLoginModal
         headerContent={
-          <Spacer gap={4} type="vertical">
-            <Text size="md" strong block>
-              새 농구장 추가를 제안하시겠습니까?
-            </Text>
-            <SubText size="xs" block>
-              제출한 코트 정보는 관리자의 승인을 거쳐 반영됩니다.
-            </SubText>
-          </Spacer>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              height: 100,
+            }}
+          >
+            <Spacer gap={4} type="vertical">
+              <Text size="md" strong block>
+                새 농구장 추가를 제안하시겠습니까?
+              </Text>
+              <SubText size="xs" block>
+                제출한 코트 정보는 관리자의 승인을 거쳐 반영됩니다.
+              </SubText>
+            </Spacer>
+          </div>
         }
         isOpen={isOpenConfirmModal}
         cancel={{
@@ -426,4 +438,11 @@ const MoveToMap = styled.a`
 
 const SubText = styled(Text)`
   color: ${({ theme }) => theme.colors.gray500};
+`;
+
+const ErrorMessage = styled(Text)`
+  text-align: right;
+  flex-grow: 1;
+  margin: 4px 0;
+  color: ${({ theme }) => theme.colors.red.strong};
 `;

--- a/src/service/managementApi/index.ts
+++ b/src/service/managementApi/index.ts
@@ -1,4 +1,4 @@
-import { request, authRequest, authFileRequest } from "../fetcher";
+import { authRequest } from "../fetcher";
 import type { ManagementApi } from "./type";
 
 const managementAPI: ManagementApi = {

--- a/src/service/managementApi/type.ts
+++ b/src/service/managementApi/type.ts
@@ -3,13 +3,13 @@ import type { ApiPromise } from "@service/type";
 
 export interface ManagementApi {
   getNewCourts: (
-    status: "READY" | "DONE",
+    status: NewCourt["status"],
     isFirst: boolean,
     lastId?: number | null
   ) => ApiPromise<{
     contents: NewCourt[];
     lastId: number;
   }>;
-  acceptNewCourt: (...params: any[]) => ApiPromise;
-  denyNewCourt: (...params: any[]) => ApiPromise;
+  acceptNewCourt: (newCourtId: NewCourt["newCourtId"]) => ApiPromise<NewCourt>;
+  denyNewCourt: (newCourtId: NewCourt["newCourtId"]) => ApiPromise<NewCourt>;
 }

--- a/src/service/userApi/index.ts
+++ b/src/service/userApi/index.ts
@@ -1,4 +1,4 @@
-import { request, authRequest, authFileRequest } from "../fetcher";
+import { authRequest, authFileRequest } from "../fetcher";
 import type { UserApi } from "./type";
 
 const userAPI: UserApi = {

--- a/src/service/userApi/type.ts
+++ b/src/service/userApi/type.ts
@@ -1,9 +1,4 @@
-import type {
-  APICourt,
-  APIFavorite,
-  APINotification,
-  APIUser,
-} from "@domainTypes/tobe";
+import type { APINotification, APIUser } from "@domainTypes/tobe";
 import type { ApiPromise } from "@service/type";
 
 export interface UserApi {


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
* 아직 백엔드 쪽에서 managementApi의 변경사항이 작업되지 않은 것 같아서 기존의 api를 기준으로 api 타입을 채워 넣었습니다.
* useForm 로직 수정으로 변경된 사항을 새 농구장 추가 form에도 적용했습니다.

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->

closes #97 

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->

- courtApi의 createNewCourt 요청을 보내면 어떨 땐 500 에러가 뜨고 어떨 땐 400 에러가 뜨고 있어요. 내일 회의 시간에 헤이에게 공유해주시면 좋을 것 같습니다.

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
