### PR TITLE
fix(next-gif): next에서 gif 최적화로 인한 정지된 애니메이션 문제 해결

### DIFF
--- a/src/components/domain/NoItemMessage/index.tsx
+++ b/src/components/domain/NoItemMessage/index.tsx
@@ -25,6 +25,7 @@ const NoItemMessage = ({
       <Image
         width={90}
         height={170}
+        unoptimized
         src={
           type === "favorite"
             ? "/assets/basketball/fire_off_favorited.gif"

--- a/src/components/domain/TimeTable/index.tsx
+++ b/src/components/domain/TimeTable/index.tsx
@@ -165,6 +165,7 @@ const TimeTable = ({ isToday, timeSlot, onModalOpen, onModalClose }: Props) => {
                   >
                     <ImageWrapper>
                       <Image
+                        unoptimized
                         src="/assets/basketball/only_ball_500.gif"
                         alt="basketball"
                       />


### PR DESCRIPTION
ISSUES CLOSED: #113

## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
### Animated Images
https://nextjs.org/docs/api-reference/next/image#animated-images
### 해결책 Next Image의 unoptimized prop을 사용하기 (default: false)
https://nextjs.org/docs/api-reference/next/image#unoptimized

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![image](https://user-images.githubusercontent.com/61593290/166889808-85ec596b-60d7-46ee-a9ad-0dee361286b1.png)

