### PR TITLE
fix(navigationProvider): 로그인 시 TopNavigation 타이틀에 '커스텀' 텍스트 제거

### DIFF
--- a/src/contexts/NavigationProvider/reducer.ts
+++ b/src/contexts/NavigationProvider/reducer.ts
@@ -27,7 +27,7 @@ export const initialData: DataProps = {
   isNotifications: true,
   isProfile: true,
   isMenu: false,
-  title: "커스텀",
+  title: "",
   handleClickBack: null,
   customButton: null,
 };


### PR DESCRIPTION
ISSUES CLOSED: #79

## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
Placeholder로 남겨놨던 텍스트, 커스텀 제거해 로그인시 탑네비게이션에 불필요한 텍스트 나오는 문제해결

#79 참고
