### PR TITLE
fix(SlotPicker): 현시간이 지난 시간 선택의 경우 클릭해도 반응이 없는 문제를 보이지 않도록 변경

### DIFF
--- a/src/components/domain/SlotPicker/index.tsx
+++ b/src/components/domain/SlotPicker/index.tsx
@@ -43,15 +43,17 @@ const SlotPicker: React.FC<SlotPickerProps> = ({
 
   return (
     <Radio.Group onChange={onChange} className={className}>
-      {slotItems.map(({ text, value }, index) => (
-        <Radio.Item
-          key={value}
-          text={text}
-          value={value}
-          checked={selectedSlot === value}
-          disabled={index < limit}
-        />
-      ))}
+      {slotItems.map(
+        ({ text, value }, index) =>
+          !(index < limit) && (
+            <Radio.Item
+              key={value}
+              text={text}
+              value={value}
+              checked={selectedSlot === value}
+            />
+          )
+      )}
     </Radio.Group>
   );
 };


### PR DESCRIPTION
ISSUES CLOSED: #124

현 시간이 slotpicker의 시간보다 앞 인경우 눌러도 반응이 없어서 유저가 헷갈리게 함 따라서 아예 나오지 않도록 수정

# To-be
<img width="699" alt="image" src="https://user-images.githubusercontent.com/61593290/168504581-6a8974a7-6e0a-4a59-99c2-4acffa79bcfd.png">
