### PR TITLE
feat(TopPageLoader): 페이지 전환시 부드러운 로딩 컴포넌트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "copy-to-clipboard": "^3.3.1",
     "dayjs": "^1.10.7",
     "feather-icons": "^4.28.0",
-    "framer-motion": "^5.3.3",
+    "framer-motion": "^6.3.11",
     "jest": "^27.4.7",
     "next": "^12.0.8",
     "react": "17.0.2",

--- a/src/components/base/TopPageLoader/index.tsx
+++ b/src/components/base/TopPageLoader/index.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import styled from "@emotion/styled";
+import Router from "next/router";
+import { useInterval, useTimeout } from "~/hooks";
+
+const TopPageLoader = () => {
+  const [isProgressBar, setIsProgressBar] = useState(true);
+  const [percentage, setPercentage] = useState(0);
+
+  useInterval(() => {
+    if (percentage < 100) {
+      setPercentage((prev) => prev + (90 - prev) / 20);
+    }
+  }, 100);
+
+  useEffect(() => {
+    if (!isProgressBar) {
+      setPercentage(100);
+    }
+  }, [isProgressBar]);
+
+  useEffect(() => {
+    setPercentage(() => 60);
+    Router.events.on("routeChangeStart", () => setIsProgressBar(true));
+    Router.events.on("routeChangeComplete", () => setIsProgressBar(false));
+    Router.events.on("routeChangeError", () => setIsProgressBar(false));
+  }, []);
+
+  useTimeout(() => {
+    setIsProgressBar(false);
+  }, 2000); // TODO: 제거 필요!! 농구장에서 새로고침시 router.events.on 동작 안함
+
+  return (
+    <Container>
+      <AnimatePresence exitBeforeEnter>
+        {isProgressBar && (
+          <ProgressBar
+            initial={{ width: `0%` }}
+            animate={{ width: `${Math.floor(percentage)}%` }}
+            exit={{ width: `100%`, height: 0 }}
+            transition={{ ease: "easeOut", duration: 0.3 }}
+          />
+        )}
+      </AnimatePresence>
+    </Container>
+  );
+};
+
+const ProgressBar = styled(motion.div)`
+  border-radius: 0 16px 16px 0;
+  height: 8px;
+  animation-duration: 2s;
+  animation-fill-mode: forwards;
+  animation-iteration-count: infinite;
+  animation-name: placeHolderShimmer;
+  animation-timing-function: linear;
+  background-color: #f6f7f8;
+  background: linear-gradient(to right, #f6f4f1 8%, #e9e5e1 18%, #f6f4f1 33%);
+  background-size: 800px 104px;
+  position: relative;
+  @keyframes placeHolderShimmer {
+    0% {
+      background-position: -800px 0;
+    }
+    100% {
+      background-position: 800px 0;
+    }
+  }
+`;
+
+const Container = styled.div`
+  width: 100%;
+`;
+
+export default TopPageLoader;

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -22,6 +22,7 @@ export { default as LinkStrong } from "./LinkStrong";
 export { default as Label } from "./Label";
 export { default as Chip } from "./Chip";
 export { default as Toast } from "./Toast";
+export { default as TopPageLoader } from "./TopPageLoader";
 /* eslint-disable import/no-cycle */
 export { default as IconButton } from "./IconButton";
 export { default as Input } from "./Input";

--- a/src/components/layout/DefaultLayout/index.tsx
+++ b/src/components/layout/DefaultLayout/index.tsx
@@ -1,16 +1,12 @@
-import type { ReactNode } from "react";
 import React, { useRef } from "react";
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { BottomNavigation, TopNavigation } from "~/components/domain";
 import { useNavigationContext } from "~/contexts/hooks";
 import Container from "./Container";
+import { TopPageLoader } from "~/components/base";
 
-interface Props {
-  children: ReactNode;
-}
-
-const DefaultLayout = ({ children }: Props) => {
+const DefaultLayout: React.FC = ({ children }) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const { navigationProps } = useNavigationContext();
@@ -19,6 +15,7 @@ const DefaultLayout = ({ children }: Props) => {
   return (
     <Container ref={containerRef}>
       {isTopNavigation && <TopNavigation />}
+      <TopPageLoader />
       <StyledMain>{children}</StyledMain>
       <ToastPortal
         id="toast-portal"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3103,14 +3103,14 @@ formdata-polyfill@^4.0.10:
   dependencies:
     fetch-blob "^3.1.2"
 
-framer-motion@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-5.3.3.tgz#366fa11512de4e79e061eb09a68278dad92b4419"
-  integrity sha512-s4mz0E4/TPTKXqKnpb578S0Jp/0JhAyvDpULFe95kHnWs1lOCKf2+EEl6yAX+1wfPLUYokZzudiK9jam0ZAVdQ==
+framer-motion@^6.3.11:
+  version "6.3.11"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-6.3.11.tgz#c304ce9728601ad9377d47d5d9264e43d741d470"
+  integrity sha512-xQLk+ZSklNs5QNCUmdWPpKMOuWiB8ZETsvcIOWw8xvri9K3TamuifgCI/B6XpaEDR0/V2ZQF2Wm+gUAZrXo+rw==
   dependencies:
     framesync "6.0.1"
     hey-listen "^1.0.8"
-    popmotion "11.0.0"
+    popmotion "11.0.3"
     style-value-types "5.0.0"
     tslib "^2.1.0"
   optionalDependencies:
@@ -3122,13 +3122,6 @@ framesync@6.0.1:
   integrity sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==
   dependencies:
     tslib "^2.1.0"
-
-framesync@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/framesync/-/framesync-6.1.0.tgz#b22cf9afba52a9a895668b09e033b6a61e901c41"
-  integrity sha512-aBX+hdWAvwiJYeQlFLY2533VxeL6OEu71CAgV4GGKksrj6+dE6i7K86WSSiRBEARCoJn5bFqffhg4l07eA27tg==
-  dependencies:
-    tslib "^2.3.1"
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -5257,12 +5250,12 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-popmotion@11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-11.0.0.tgz#910e2e7077d9aeba520db8744d40bb5354992212"
-  integrity sha512-kJDyaG00TtcANP5JZ51od+DCqopxBm2a/Txh3Usu23L9qntjY5wumvcVf578N8qXEHR1a+jx9XCv8zOntdYalQ==
+popmotion@11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-11.0.3.tgz#565c5f6590bbcddab7a33a074bb2ba97e24b0cc9"
+  integrity sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==
   dependencies:
-    framesync "^6.0.1"
+    framesync "6.0.1"
     hey-listen "^1.0.8"
     style-value-types "5.0.0"
     tslib "^2.1.0"
@@ -6386,7 +6379,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0, tslib@^2.3.1:
+tslib@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->
ISSUES CLOSED: #151

## 변경사항
상단 탑네비게이션 바 아래 로딩 프로그레스 바 추가

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![chrome-capture-2022-5-11](https://user-images.githubusercontent.com/61593290/173113686-d97bd8c7-ac6b-49c9-ae25-8e228f2139ab.gif)

