### PR TITLE
feat(TopNavigation): 스크롤시 타이틀 작아지면서 위치 이동해 내용의 가독성 향상시키기

### DIFF
--- a/src/components/domains/TopNavigation/index.tsx
+++ b/src/components/domains/TopNavigation/index.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useRef } from "react"
 import Link from "next/link"
 import { useRouter } from "next/router"
 import styled from "@emotion/styled"
+import { motion } from "framer-motion"
 import { ProfileAvatar } from "~/components/domains"
 import { Icon, Badge } from "~/components/uis/atoms"
 import { useAuthContext, useNavigationContext } from "~/contexts/hooks"
@@ -11,17 +12,18 @@ const TopNavigation = () => {
 
   const { authProps } = useAuthContext()
 
+  const { navigationProps } = useNavigationContext()
+
   const {
-    navigationProps: {
-      isBack,
-      isNotifications,
-      title,
-      isMenu,
-      handleClickBack,
-      customButton,
-      isProfile,
-    },
-  } = useNavigationContext()
+    isBack,
+    isNotifications,
+    title,
+    isMenu,
+    handleClickBack,
+    customButton,
+    isProfile,
+    isTopNavShrink,
+  } = navigationProps
 
   const router = useRouter()
 
@@ -40,7 +42,17 @@ const TopNavigation = () => {
 
   return (
     <>
-      <Container>
+      <Container
+        initial={{ background: undefined }}
+        animate={
+          isTopNavShrink
+            ? {
+                background:
+                  "linear-gradient(rgba(250,250,250,1),rgba(250,250,250,1),rgba(250,250,250,1), rgba(250,250,250, 0))",
+              }
+            : { background: undefined }
+        }
+      >
         <Wrapper>
           <IconGroup>
             {isBack && (
@@ -77,7 +89,16 @@ const TopNavigation = () => {
             )}
           </IconGroup>
         </Wrapper>
-        <TitleWrapper>{title}</TitleWrapper>
+        <TitleWrapper
+          initial={{ originX: 0, y: 0, scale: 1 }}
+          animate={
+            isTopNavShrink
+              ? { originX: 0, y: -40, scale: 0.7 }
+              : { originX: 0, y: 0, scale: 1 }
+          }
+        >
+          {title}
+        </TitleWrapper>
       </Container>
 
       <TopNavigationSensor ref={sensorRef} />
@@ -87,7 +108,7 @@ const TopNavigation = () => {
 
 export default TopNavigation
 
-const Container = styled.nav`
+const Container = styled(motion.nav)`
   z-index: 1000;
   position: sticky;
   top: 0;
@@ -112,9 +133,9 @@ const Wrapper = styled.div`
   padding: 12px 12px 6px 16px;
 `
 
-const TitleWrapper = styled.div`
-  font-weight: 700;
+const TitleWrapper = styled(motion.div)`
   font-size: 28px;
+  font-weight: 700;
   display: flex;
   justify-content: flex-start;
   align-items: center;

--- a/src/components/domains/layout/DefaultLayout/index.tsx
+++ b/src/components/domains/layout/DefaultLayout/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react"
+import React, { useEffect, useRef } from "react"
 import { css } from "@emotion/react"
 import styled from "@emotion/styled"
 import { BottomNavigation, TopNavigation } from "~/components/domains"
@@ -9,8 +9,24 @@ import Container from "./Container"
 const DefaultLayout: React.FC = ({ children }) => {
   const containerRef = useRef<HTMLDivElement>(null)
 
-  const { navigationProps } = useNavigationContext()
+  const { navigationProps, setTopNavIsShrink } = useNavigationContext()
   const { isBottomNavigation, isTopNavigation } = navigationProps
+
+  const setTopIsShrinkByScroll = () => {
+    if (containerRef.current) {
+      setTopNavIsShrink(containerRef.current.scrollTop > 80)
+    }
+  }
+
+  useEffect(() => {
+    containerRef.current?.addEventListener("scroll", setTopIsShrinkByScroll)
+
+    return () =>
+      containerRef.current?.removeEventListener(
+        "scroll",
+        setTopIsShrinkByScroll
+      )
+  }, [containerRef])
 
   return (
     <Container ref={containerRef}>

--- a/src/contexts/NavigationProvider/actionTypes.ts
+++ b/src/contexts/NavigationProvider/actionTypes.ts
@@ -12,10 +12,9 @@ type EventAction =
     >
   | ActionWithoutPayload<"EVENT_CLEAR">
 
-type NavigationAction = ActionWithPayload<
-  "NAVIGATION_SET_TITLE",
-  { title: ReactNode }
->
+type NavigationAction =
+  | ActionWithPayload<"NAVIGATION_SET_TITLE", { title: ReactNode }>
+  | ActionWithPayload<"SET_TOP_NAV_IS_SHRINK", { isShrink: boolean }>
 
 type PageAction =
   | ActionWithoutPayload<"PAGE_NONE">

--- a/src/contexts/NavigationProvider/context.ts
+++ b/src/contexts/NavigationProvider/context.ts
@@ -16,6 +16,7 @@ export interface ContextProps {
   ) => void
   clearNavigationEvent: () => void
   setNavigationTitle: (title: ReactNode) => void
+  setTopNavIsShrink: (isShrink: boolean) => void
 }
 
 const initialContext = {
@@ -26,6 +27,7 @@ const initialContext = {
   useMountCustomButtonEvent: () => {},
   clearNavigationEvent: () => {},
   setNavigationTitle: () => {},
+  setTopNavIsShrink: () => {},
 }
 
 const Context = createContext<ContextProps>(initialContext)

--- a/src/contexts/NavigationProvider/index.tsx
+++ b/src/contexts/NavigationProvider/index.tsx
@@ -7,6 +7,10 @@ import { reducer, initialData } from "./reducer"
 const NavigationProvider: FC = ({ children }) => {
   const [navigationProps, dispatch] = useReducer(reducer, initialData)
 
+  const setTopNavIsShrink = (isShrink: boolean) => {
+    dispatch({ type: "SET_TOP_NAV_IS_SHRINK", payload: { isShrink } })
+  }
+
   const useMountPage: ContextProps["useMountPage"] = (currentPageType) =>
     useEffect(() => {
       dispatch({ type: currentPageType })
@@ -62,6 +66,7 @@ const NavigationProvider: FC = ({ children }) => {
         setCustomButtonEvent,
         clearNavigationEvent,
         useMountCustomButtonEvent,
+        setTopNavIsShrink,
       }}
     >
       {children}

--- a/src/contexts/NavigationProvider/reducer.ts
+++ b/src/contexts/NavigationProvider/reducer.ts
@@ -10,6 +10,7 @@ export interface DataProps {
   isProfile: boolean
   isMenu: boolean
   title: ReactNode
+  isTopNavShrink: boolean
   handleClickBack: null | (() => void)
   customButton: null | {
     title: ReactNode
@@ -26,6 +27,7 @@ export const initialData: DataProps = {
   isProfile: true,
   isMenu: false,
   title: "",
+  isTopNavShrink: false,
   handleClickBack: null,
   customButton: null,
 }
@@ -238,6 +240,14 @@ export const reducer: Reducer<DataProps, Action> = (prevState, action) => {
         title,
       }
     }
+    case "SET_TOP_NAV_IS_SHRINK": {
+      const { isShrink } = action.payload
+
+      return {
+        ...prevState,
+        isTopNavShrink: isShrink,
+      }
+    }
     case "EVENT_BIND": {
       const { back, customButton } = action.payload.events
 
@@ -266,7 +276,7 @@ export const reducer: Reducer<DataProps, Action> = (prevState, action) => {
       }
     }
     default: {
-      return { ...prevState }
+      return prevState
     }
   }
 }


### PR DESCRIPTION
ISSUES CLOSED: #161

## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
스크롤시에 타이틀의 위치를 변경시켜 가독성을 향상시킵니다
앱과 같은 경험을 웹에서도 구현합니다

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![chrome-capture-2022-5-25](https://user-images.githubusercontent.com/61593290/175760432-1c9edf49-5c32-483b-aeec-b42505e385b7.gif)