### PR TITLE
feat(pages/reservations/courts/[courtId]): 예약 페이지 개편 (날짜별로 따로 페이지 -> 무한 스크롤로 모든 예약가능한 날짜/시간 이어서 보기)

### DIFF
--- a/src/components/domains/ReservationTable/Cell.tsx
+++ b/src/components/domains/ReservationTable/Cell.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react"
+import { useEffect, useRef } from "react"
+import { useRouter } from "next/router"
+import { css } from "@emotion/react"
+import styled from "@emotion/styled"
+import { useNavigationContext } from "~/contexts/hooks"
+import { useIntersectionObserver } from "~/hooks"
+import { useReservationTableContext } from "./context"
+
+interface Props {
+  isOddTimeNumber: boolean
+  isTop: boolean
+  timeNumber: number
+  intersectingTitle: string
+  children: ReactNode
+}
+
+const Cell = ({
+  isOddTimeNumber,
+  intersectingTitle,
+  isTop,
+  timeNumber,
+  children,
+}: Props) => {
+  const { tableCellHeight } = useReservationTableContext()
+  const router = useRouter()
+  const { courtId } = router.query
+
+  const { setNavigationTitle } = useNavigationContext()
+  const ref = useRef<HTMLDivElement>(null)
+  const entry = useIntersectionObserver(ref, {})
+
+  useEffect(() => {
+    if (isTop && entry?.isIntersecting) {
+      router.replace(
+        `/reservations/courts/${courtId}?date=${intersectingTitle}`
+      )
+      setNavigationTitle(intersectingTitle)
+    }
+    if (timeNumber === 36 && entry?.isIntersecting) {
+      router.replace(
+        `/reservations/courts/${courtId}?date=${intersectingTitle}`
+      )
+      setNavigationTitle(intersectingTitle)
+    }
+  }, [entry?.isIntersecting])
+
+  return (
+    <S.Cell
+      ref={ref}
+      tableCellHeight={tableCellHeight}
+      isTop={isTop}
+      isOddTimeNumber={isOddTimeNumber}
+    >
+      {children}
+    </S.Cell>
+  )
+}
+
+export default Cell
+
+const S = {
+  Cell: styled.div<{
+    tableCellHeight: number
+    isTop: boolean
+    isOddTimeNumber: boolean
+  }>`
+    ${({ theme, isOddTimeNumber, tableCellHeight, isTop }) => css`
+      box-sizing: border-box;
+      background-color: orange;
+      height: ${tableCellHeight}px;
+      border-top: ${isTop ? 18 : isOddTimeNumber ? 2 : 1}px solid
+        ${theme.colors.black};
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+    `}
+  `,
+}

--- a/src/components/domains/ReservationTable/Cells.tsx
+++ b/src/components/domains/ReservationTable/Cells.tsx
@@ -1,0 +1,53 @@
+import React from "react"
+import Cell from "./Cell"
+import { useReservationTableContext } from "./context"
+
+const Cells = () => {
+  const { dates } = useReservationTableContext()
+
+  return (
+    <>
+      {dates
+        .map(
+          // 하루의 표 48개 생성
+          (date) =>
+            Array.from(Array(48).keys()).map((_, index) => ({
+              timeNumber: index,
+              intersectingTitle: date,
+            }))
+        )
+        .reduce(
+          // 여러 날의의 표 한배열로 뭉치기
+          (acc, cur) =>
+            [
+              ...acc,
+              ...cur.map(({ intersectingTitle, timeNumber }) => {
+                const hour = Math.floor(timeNumber / 2)
+                const isOddTimeNumber = Math.abs(timeNumber % 2) === 0
+                const isTop = hour === 0 && isOddTimeNumber
+                const isBottom = hour === 23 && !isOddTimeNumber
+
+                return (
+                  <Cell
+                    isOddTimeNumber={isOddTimeNumber}
+                    key={`${intersectingTitle}-${timeNumber}`}
+                    intersectingTitle={intersectingTitle}
+                    isTop={isTop}
+                    timeNumber={timeNumber}
+                  >
+                    {isTop && <div>{intersectingTitle}</div>}
+                    {isOddTimeNumber
+                      ? `${hour}시 - ${hour}시 30분`
+                      : `${hour}시  30분 - ${hour + 1}시`}
+                    {isBottom && <div>{intersectingTitle}</div>}
+                  </Cell>
+                )
+              }),
+            ] as { intersectingTitle: string; timeNumber: number }[],
+          []
+        )}
+    </>
+  )
+}
+
+export default Cells

--- a/src/components/domains/ReservationTable/Divider.tsx
+++ b/src/components/domains/ReservationTable/Divider.tsx
@@ -1,0 +1,21 @@
+import styled from "@emotion/styled"
+import { useReservationTableContext } from "./context"
+
+const Divider = () => {
+  const { tableCellHeight } = useReservationTableContext()
+
+  return <S.Divider tableCellHeight={tableCellHeight} />
+}
+
+export default Divider
+
+const S = {
+  Divider: styled.div<{ tableCellHeight: number }>`
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: ${({ tableCellHeight }) => tableCellHeight}px;
+    width: 6px;
+    background-color: black;
+  `,
+}

--- a/src/components/domains/ReservationTable/MoreCellSensor.tsx
+++ b/src/components/domains/ReservationTable/MoreCellSensor.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState } from "react"
+import { css } from "@emotion/react"
+import styled from "@emotion/styled"
+import { useIntersectionObserver } from "~/hooks"
+import { useReservationTableContext } from "./context"
+
+const SENSOR_MULTIPLY = 6
+
+const Top = () => {
+  const [isSensorOff, setIsSensorOff] = useState(false)
+  const { replaceNewDate, tableCellHeight } = useReservationTableContext()
+  const sensorRef = useRef<HTMLDivElement>(null)
+  const sensorEntry = useIntersectionObserver(sensorRef, {
+    threshold: 0.5,
+  })
+  const isMounted = useRef(false)
+
+  useEffect(() => {
+    if (isMounted.current) {
+      if (sensorEntry?.isIntersecting) {
+        replaceNewDate("subtract", ({ isAddedCells }) => {
+          document.getElementById("scrolled-container")?.scrollTo({
+            top:
+              // subtract이 실패한 경우(isAddedCells === false)(최소 날짜를 벗어난 요청의 경우, 14일 제한) 새로운 테이블을 받아오지 않았으므로
+              (isAddedCells ? tableCellHeight * 48 : 0) +
+              Math.abs(sensorRef.current?.getClientRects()[0].height || 0), // 스크롤이 센서의 바텀으로 되어야 함
+          })
+
+          if (!isAddedCells) {
+            setIsSensorOff(true)
+          }
+        })
+      }
+    } else {
+      document
+        .getElementById("scrolled-container")
+        ?.scrollTo({ top: tableCellHeight * SENSOR_MULTIPLY })
+    }
+    isMounted.current = true
+  }, [sensorEntry?.isIntersecting])
+
+  if (isSensorOff) {
+    return (
+      <>
+        <NoAccessScrollMaker />
+        <NoAccess>지난 날은 예약할 수 없습니다</NoAccess>
+      </>
+    )
+  }
+
+  return (
+    <MoreTableMaker
+      ref={sensorRef}
+      tableCellHeight={tableCellHeight}
+      colorInterecting={!!sensorEntry?.isIntersecting}
+    />
+  )
+}
+
+const Bottom = () => {
+  const [isSensorOff, setIsSensorOff] = useState(false)
+  const { replaceNewDate, tableCellHeight } = useReservationTableContext()
+  const sensorRef = useRef<HTMLDivElement>(null)
+  const sensorEntry = useIntersectionObserver(sensorRef, {})
+
+  useEffect(() => {
+    if (sensorEntry?.isIntersecting) {
+      replaceNewDate("add", ({ isAddedCells }) => {
+        if (!isAddedCells) {
+          setIsSensorOff(true)
+        }
+      })
+    }
+  }, [sensorEntry?.isIntersecting])
+
+  if (isSensorOff) {
+    return <NoAccess>오늘로부터 14일 후는 예약할 수 없습니다</NoAccess>
+  }
+
+  return (
+    <MoreTableMaker
+      ref={sensorRef}
+      tableCellHeight={tableCellHeight}
+      colorInterecting={!!sensorEntry?.isIntersecting}
+    />
+  )
+}
+
+export default {
+  Top,
+  Bottom,
+}
+
+const MoreTableMaker = styled.div<{
+  tableCellHeight: number
+  colorInterecting: boolean
+}>`
+  background-color: ${({ colorInterecting }) =>
+    colorInterecting ? "blue" : "red"};
+  height: ${({ tableCellHeight }) => tableCellHeight * SENSOR_MULTIPLY}px;
+`
+
+const NoAccess = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 16px;
+    background-color: ${theme.colors.gray0200};
+    color: ${theme.colors.gray0500};
+  `}
+`
+
+const NoAccessScrollMaker = () => {
+  const ref = useRef(null)
+
+  const entry = useIntersectionObserver(ref, { threshold: 0.95 })
+
+  useEffect(() => {
+    if (entry?.isIntersecting) {
+      document
+        .getElementById("scrolled-container")
+        ?.scrollTo({ top: entry.boundingClientRect.bottom })
+    }
+  }, [entry?.isIntersecting])
+
+  return <ScrollMaker ref={ref} />
+}
+
+const ScrollMaker = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: ${theme.colors.gray0200};
+    color: ${theme.colors.gray0500};
+    height: 20vh;
+  `}
+`

--- a/src/components/domains/ReservationTable/context.ts
+++ b/src/components/domains/ReservationTable/context.ts
@@ -1,0 +1,21 @@
+import type { Dispatch, SetStateAction } from "react"
+import { createContext, useContext } from "react"
+
+export interface ContextProps {
+  intersectingTitleCountMap: { [date: string]: number }
+  setIntersectingTitleCountMap: Dispatch<
+    SetStateAction<{ [date: string]: number }>
+  >
+  tableCellHeight: number
+  dates: string[]
+  setDates: Dispatch<SetStateAction<string[]>>
+  replaceNewDate: (
+    option: "add" | "subtract",
+    callback?: ({ isAddedCells }: { isAddedCells: boolean }) => void
+  ) => void
+}
+
+export const ReservationTableContext = createContext({} as ContextProps)
+
+export const useReservationTableContext = () =>
+  useContext(ReservationTableContext)

--- a/src/components/domains/ReservationTable/index.tsx
+++ b/src/components/domains/ReservationTable/index.tsx
@@ -1,0 +1,134 @@
+import type { ReactNode } from "react"
+import React, { useMemo, useCallback, useState, useEffect, useRef } from "react"
+import { useRouter } from "next/router"
+import dayjs from "dayjs"
+import { Spacer } from "~/components/uis/atoms"
+import { useNavigationContext } from "~/contexts/hooks"
+import { useDebounce } from "~/hooks"
+import Cells from "./Cells"
+import type { ContextProps } from "./context"
+import { ReservationTableContext } from "./context"
+import Divider from "./Divider"
+import MoreCellSensor from "./MoreCellSensor"
+import "dayjs/locale/ko"
+
+dayjs.locale("ko")
+
+const DATE_QUERY_STRING_FORMAT = "YYYY-MM-DD"
+
+interface Props {
+  children: ReactNode
+}
+
+const ReservationTable = ({ children }: Props) => {
+  const router = useRouter()
+  const { courtId, date } = router.query
+
+  const [intersectingTitleCountMap, setIntersectingTitleCountMap] = useState<{
+    [date: string]: number
+  }>({})
+
+  const dayjsToday = dayjs()
+  const dayjsDate = {
+    Current: dayjs(`${date}`),
+    Min: dayjsToday,
+    Max: dayjs(dayjsToday.clone()).add(13, "day"),
+  }
+
+  const [dates, setDates] = useState([
+    dayjsDate.Current.format(DATE_QUERY_STRING_FORMAT),
+  ])
+  const vwElementRef = useRef<HTMLDivElement>(null)
+  const tableCellHeight = useMemo(
+    () => (vwElementRef.current?.clientWidth || 6) / 6,
+    [vwElementRef.current?.clientWidth]
+  )
+  const isReadyTableCellHeight = tableCellHeight > 10
+
+  const replaceNewDate: ContextProps["replaceNewDate"] = useCallback(
+    async (option, callback) => {
+      if (
+        (option === "subtract" && dayjs(dates[0]).isBefore(dayjsDate.Min)) ||
+        (option === "add" &&
+          dayjs(dates[dates.length - 1]).isAfter(dayjsDate.Max))
+      ) {
+        if (typeof callback === "function") {
+          await callback({ isAddedCells: false })
+        }
+
+        return
+      }
+
+      if (option === "subtract") {
+        setDates((prev) => [
+          dayjs(prev[0]).subtract(1, "day").format(DATE_QUERY_STRING_FORMAT),
+          ...prev,
+        ])
+      }
+      if (option === "add") {
+        setDates((prev) => [
+          ...prev,
+          dayjs(prev[prev.length - 1])
+            .add(1, "day")
+            .format(DATE_QUERY_STRING_FORMAT),
+        ])
+      }
+      if (typeof callback === "function") {
+        await callback({ isAddedCells: true })
+      }
+    },
+    [dates, dayjsDate.Max, dayjsDate.Min]
+  )
+
+  useEffect(() => {
+    if (dayjsDate.Current.isBefore(dayjsDate.Min.subtract(1, "day"))) {
+      router.replace(
+        `/reservations/courts/${courtId}?date=${dayjsDate.Min.format(
+          DATE_QUERY_STRING_FORMAT
+        )}`
+      )
+    }
+
+    if (dayjsDate.Current.isAfter(dayjsDate.Max.add(1, "day"))) {
+      router.replace(
+        `/reservations/courts/${courtId}?date=${dayjsDate.Max.format(
+          DATE_QUERY_STRING_FORMAT
+        )}`
+      )
+    }
+  }, [date, courtId, router])
+
+  return (
+    <ReservationTableContext.Provider
+      value={{
+        intersectingTitleCountMap,
+        setIntersectingTitleCountMap,
+        tableCellHeight,
+        dates,
+        setDates,
+        replaceNewDate,
+      }}
+    >
+      <Spacer
+        ref={vwElementRef}
+        justify="space-between"
+        style={{ position: "relative" }}
+      >
+        {isReadyTableCellHeight ? (
+          <>
+            <MoreCellSensor.Top />
+            {children}
+            <MoreCellSensor.Bottom />
+          </>
+        ) : (
+          <>테이블 그리기를 준비중입니다.</>
+        )}
+      </Spacer>
+    </ReservationTableContext.Provider>
+  )
+}
+
+export default ReservationTable
+
+ReservationTable.Divider = Divider
+ReservationTable.Cells = Cells

--- a/src/components/domains/TopNavigation/index.tsx
+++ b/src/components/domains/TopNavigation/index.tsx
@@ -10,7 +10,8 @@ import { useAuthContext, useNavigationContext } from "~/contexts/hooks"
 
 const titleWrapperVariants: Variants = {
   notShrink: { originX: 0, x: 0, y: 0, scale: 1 },
-  shrink: { originX: 0, x: 4, y: -40, scale: 0.7 },
+  shrink: { originX: 0, x: 6, y: -40, scale: 0.7 },
+  shrinkWithBack: { originX: 0, x: 30, y: -40, scale: 0.7 },
 }
 
 const TopNavigation = () => {
@@ -93,10 +94,17 @@ const TopNavigation = () => {
             )}
           </IconGroup>
         </Wrapper>
+
         <TitleWrapper
           variants={titleWrapperVariants}
           initial="notShrink"
-          animate={isTopNavShrink ? "shrink" : "notShrink"}
+          animate={
+            isTopNavShrink
+              ? isBack
+                ? "shrinkWithBack"
+                : "shrink"
+              : "notShrink"
+          }
         >
           {title}
         </TitleWrapper>

--- a/src/components/domains/index.ts
+++ b/src/components/domains/index.ts
@@ -16,6 +16,7 @@ export { PositionsPicker, ProficiencyPicker } from "./UserInfoPicker"
 export { default as NoItemMessage } from "./NoItemMessage"
 export { default as ProfileFavoritesListItem } from "./ProfileFavoritesListItem"
 export { default as ProfileAvatar } from "./ProfileAvatar"
+export { default as ReservationTable } from "./ReservationTable"
 /* eslint-disable import/no-cycle */
 export { default as FavoriteList } from "./FavoriteList"
 export { default as LeadToLoginModal } from "./LeadToLoginModal"

--- a/src/contexts/NavigationProvider/actionTypes.ts
+++ b/src/contexts/NavigationProvider/actionTypes.ts
@@ -22,6 +22,7 @@ type PageAction =
   | ActionWithoutPayload<"PAGE_LOGIN">
   | ActionWithoutPayload<"PAGE_MAP">
   | ActionWithoutPayload<"PAGE_RESERVATIONS">
+  | ActionWithoutPayload<"PAGE_RESERVATIONS_COURTS">
   | ActionWithoutPayload<"PAGE_COURT_RESERVATIONS">
   | ActionWithoutPayload<"PAGE_ACTIVITY">
   | ActionWithoutPayload<"PAGE_COURT_CREATE">

--- a/src/contexts/NavigationProvider/reducer.ts
+++ b/src/contexts/NavigationProvider/reducer.ts
@@ -112,6 +112,19 @@ export const reducer: Reducer<DataProps, Action> = (prevState, action) => {
         title: "예약",
       }
     }
+    case "PAGE_RESERVATIONS_COURTS": {
+      return {
+        ...prevState,
+        isTopNavigation: true,
+        isBottomNavigation: true,
+        currentPage: action.type,
+        isBack: true,
+        isNotifications: true,
+        isProfile: true,
+        isMenu: false,
+        title: "",
+      }
+    }
     case "PAGE_ACTIVITY": {
       return {
         ...prevState,

--- a/src/pages/courts/index.tsx
+++ b/src/pages/courts/index.tsx
@@ -342,15 +342,9 @@ const Courts: NextPage = () => {
 
               {localToken ? (
                 <Link
-                  href={{
-                    pathname: `/courts/[courtId]/[date]`,
-                    query: {
-                      timeSlot: "morning",
-                    },
-                  }}
-                  as={`/courts/${
+                  href={`reservations/courts/${
                     selectedMarker.court.id
-                  }/${getTimezoneDateStringFromDate(selectedDate)}`}
+                  }?date=${getTimezoneDateStringFromDate(selectedDate)}`}
                   passHref
                 >
                   <a style={{ flex: 1, display: "flex" }}>

--- a/src/pages/reservations/courts/[courtId]/index.tsx
+++ b/src/pages/reservations/courts/[courtId]/index.tsx
@@ -1,0 +1,19 @@
+import type { NextPage } from "next"
+import { ReservationTable } from "~/components/domains"
+import { useNavigationContext } from "~/contexts/hooks"
+import { withRouteGuard } from "~/hocs"
+
+const ReservationOfCourtPage: NextPage = withRouteGuard("private", () => {
+  const { useMountPage } = useNavigationContext()
+
+  useMountPage("PAGE_RESERVATIONS_COURTS")
+
+  return (
+    <ReservationTable>
+      <ReservationTable.Divider />
+      <ReservationTable.Cells />
+    </ReservationTable>
+  )
+})
+
+export default ReservationOfCourtPage


### PR DESCRIPTION
ISSUES CLOSED: #164

## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
@KwonYeKyeong @locodingve 그 때 회의했던 내용 구현해봤어요
무한 스크롤 이후에 예약 데이터 fetch 받아서 cell에 맵핑 시켜주면 될 것 같아요
develop으로 머지해놓을테니 개발용 도메인에서 확인해보실 수 있을 거에요

### Asis
#### 문제점: 기존 예약페이지 유저경험 아쉬움
- 기존 예약 페이지에서는 10시 - 다음날 새벽 2시 예약이 불가능했음
- 다음 페이지로 넘어가야만 해서 유저의 연속성이 깨짐

### Tobe
#### 해결책: 무한 스크롤로 모든 페이지를 이어서 보여줌

1. 무한 스크롤 시 queryParam을 현재 날짜로 replace해 링크로 공유하는 경우 고려
2. 무한 스크롤 시 위아래 날짜가 제한된 경우 더이상 받아올 수 없도록 제한 (아래 gif에서 회색 박스로 표현됨)
3. 무한 스크롤 시 더 받아올 날짜가 있는 경우 보여줄 배열에 push, unshift로 넣어서 시간 렌더링
4. 최상단으로 가는 경우 스크롤 여유 공간을 만들어 타이틀 shrinkIntersectionObserver Sensor가 항상 shrink 상태를 유지하게 설정
5. TopNavigation 타이틀에 날짜를 표시해 예약 시점의 직관성을 향상 시켰습니다. (1번째와 36번째 cell이 intersecting되는 경우 title을 변경하도록 구현했습니다.)

## PR 포인트
1. container의 width의 1/6 크기로 cell하나를 제한해 농구공 유무를 표현할 위치를 정사각형을 유지할 수 있게 구현
2. container의 width를 받아오는 동안 표가 나오지않도록 제한 (해당 상태: isReadyTableCellHeight)

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![chrome-capture-2022-5-30](https://user-images.githubusercontent.com/61593290/176661237-6284f466-f44f-4441-b7c6-f132fad01af8.gif)
