### PR TITLE
fix(IconButton): normalize.css에 포함 되어있는 font-size:100% 제거해 iOS에서 아이콘 쪼그라드는 문제 해결

### DIFF
--- a/src/components/uis/atoms/Icon/index.tsx
+++ b/src/components/uis/atoms/Icon/index.tsx
@@ -1,4 +1,5 @@
 import type { ComponentProps } from "react"
+import Image from "next/image"
 import { css } from "@emotion/react"
 import styled from "@emotion/styled"
 import Icons from "feather-icons"
@@ -310,7 +311,12 @@ const Icon = ({
 
   return (
     <IconWrapper {...props} size={size} rotate={rotate}>
-      <img src={`data:image/svg+xml;base64,${base64}`} alt={name} />
+      <Image
+        width={24}
+        height={24}
+        src={`data:image/svg+xml;base64,${base64}`}
+        alt={name}
+      />
     </IconWrapper>
   )
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -65,7 +65,6 @@ optgroup,
 select,
 textarea {
   font-family: inherit;
-  font-size: 100%;
   line-height: 1.15;
   margin: 0;
 }


### PR DESCRIPTION
ISSUES CLOSED: #184

## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
iOS에서만 IconButton의 아이콘이 쪼그라드는 문제 해결
함께 next/image로 변경

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
### AS-IS
![image](https://user-images.githubusercontent.com/61593290/176742450-6c8c3e08-93a9-4799-8627-9c78a61bc574.png)
### TO-BE
![image](https://user-images.githubusercontent.com/61593290/176742544-79b0b9a9-0d4a-4f9e-a02a-c1ef630987bf.png)

